### PR TITLE
update check

### DIFF
--- a/py_fuscate.py
+++ b/py_fuscate.py
@@ -106,7 +106,7 @@ def check_update():
     global LATEST_VER
     LATEST_VER = requests.get('https://raw.githubusercontent.com/Sl-Sanda-Ru/Py-Fuscate/main/.version').text.strip()
     with open('.version') as version:
-        if int(version.read().strip()) < LATEST_VER:
+        if version.read().strip() < LATEST_VER:
             return True
         else:
             return False


### PR DESCRIPTION
The version in the .version file is a float not an integer for one. And two, it's stored as a string.

This will make the following error happen every time the script is ran.
```zsh
Traceback (most recent call last):
  File "/home/ori/Desktop/Projects/currently_active/so_Testing/py_fuscate.py", line 158, in <module>
    main()
  File "/home/ori/Desktop/Projects/currently_active/so_Testing/py_fuscate.py", line 127, in main
    if check_update():
  File "/home/ori/Desktop/Projects/currently_active/so_Testing/py_fuscate.py", line 109, in check_update
    if int(version.read().strip()) < LATEST_VER:
ValueError: invalid literal for int() with base 10: '1.5'
``` 

Removing the int() around `version.read().strip()` will fix this error all while still working how you want it to work.